### PR TITLE
feat: support hyphenated-files, export names in camelCase

### DIFF
--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -14,7 +14,7 @@ const buildExportBlock = (files) => {
   let importBlock;
 
   importBlock = _.map(files, (fileName) => {
-    return 'export ' + safeVariableName(fileName) + ' from \'./' + fileName + '\';';
+    return 'export ' + _.camelCase(safeVariableName(fileName)) + ' from \'./' + fileName + '\';';
   });
 
   importBlock = importBlock.join('\n');

--- a/src/utilities/readDirectory.js
+++ b/src/utilities/readDirectory.js
@@ -28,7 +28,7 @@ const hasMultipleExtensions = (fileName) => {
 };
 
 const isSafeName = (fileName) => {
-  return /^[a-z][a-z0-9._]+$/i.test(fileName);
+  return /^[a-z][a-z0-9._-]+$/i.test(fileName);
 };
 
 const removeDuplicates = (files) => {

--- a/test/readDirectory.js
+++ b/test/readDirectory.js
@@ -25,7 +25,7 @@ describe('readDirectory()', () => {
     it('gets names of the children directories', () => {
       const names = readDirectory(path.resolve(fixturesPath, 'children-directories-unsafe-name'));
 
-      expect(names).to.deep.equal(['present']);
+      expect(names).to.deep.equal(['bar-bar', 'foo-foo', 'present']);
     });
   });
   context('target directory contains ./index.js', () => {


### PR DESCRIPTION
This adds support for `hyphenated-files`

The exported names are now also in camelCase
