### PR TITLE
feat: add a default export

### DIFF
--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -14,8 +14,19 @@ const buildExportBlock = (files) => {
   let importBlock;
 
   importBlock = _.map(files, (fileName) => {
-    return 'export ' + safeVariableName(fileName) + ' from \'./' + fileName + '\';';
+    const moduleName = _.camelCase(safeVariableName(fileName));
+
+    return 'import _' + moduleName + ' from \'./' + fileName + '\';\n' +
+       'export const ' + moduleName + ' = _' + moduleName + ';\n';
   });
+
+  importBlock.push('export default {');
+  importBlock.push.apply(importBlock, _.map(files, (fileName, idx) => {
+    const moduleName = _.camelCase(safeVariableName(fileName));
+
+    return '  ' + moduleName + (idx + 1 < files.length ? ',' : '');
+  }), '');
+  importBlock.push('};');
 
   importBlock = importBlock.join('\n');
 

--- a/test/createIndexCode.js
+++ b/test/createIndexCode.js
@@ -20,7 +20,12 @@ describe('createIndexCode()', () => {
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export foo from './foo';
+import _foo from './foo';
+export const foo = _foo;
+
+export default {
+  foo
+};
         `));
   });
   it('describes multiple children', () => {
@@ -29,8 +34,16 @@ export foo from './foo';
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export bar from './bar';
-export foo from './foo';
+import _bar from './bar';
+export const bar = _bar;
+
+import _foo from './foo';
+export const foo = _foo;
+
+export default {
+  bar,
+  foo
+};
         `));
   });
   context('file with extension', () => {
@@ -40,7 +53,12 @@ export foo from './foo';
       expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export foo from './foo.js';
+import _foo from './foo.js';
+export const foo = _foo;
+
+export default {
+  foo
+};
             `));
     });
   });
@@ -51,8 +69,16 @@ export foo from './foo.js';
       expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export bar from './bar';
-export foo from './foo';
+import _bar from './bar';
+export const bar = _bar;
+
+import _foo from './foo';
+export const foo = _foo;
+
+export default {
+  bar,
+  foo
+};
             `));
     });
   });

--- a/test/fixtures/write-index/mixed/index.js
+++ b/test/fixtures/write-index/mixed/index.js
@@ -1,5 +1,13 @@
 // @create-index
 
-export bar from './bar';
-export foo from './foo.js';
+import _bar from './bar';
+export const bar = _bar;
+
+import _foo from './foo.js';
+export const foo = _foo;
+
+export default {
+  bar,
+  foo
+};
 

--- a/test/writeIndex.js
+++ b/test/writeIndex.js
@@ -29,8 +29,16 @@ describe('writeIndex()', () => {
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export bar from './bar';
-export foo from './foo.js';
+import _bar from './bar';
+export const bar = _bar;
+
+import _foo from './foo.js';
+export const foo = _foo;
+
+export default {
+  bar,
+  foo
+};
         `));
   });
 });


### PR DESCRIPTION
This adds a default export object containing all named exports.

Eg.:
```js
// @create-index

export king from './king.js'
export queen from './queen'
export default {
  king,
  queen
}
```

Fixes #11

Keeps `camelCase` support from #16