### PR TITLE
fix: update stopped working with banner

### DIFF
--- a/test/fixtures/validate-target-directory/safe-index-with-banner/index.js
+++ b/test/fixtures/validate-target-directory/safe-index-with-banner/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+// @create-index

--- a/test/validateTargetDirectory.js
+++ b/test/validateTargetDirectory.js
@@ -36,6 +36,11 @@ describe('validateTargetDirectory()', () => {
         expect(validateTargetDirectory(path.resolve(fixturesPath, 'safe-index'))).to.equal(true);
       });
     });
+    context('safe with banner', () => {
+      it('returns true', () => {
+        expect(validateTargetDirectory(path.resolve(fixturesPath, 'safe-index-with-banner'))).to.equal(true);
+      });
+    });
     context('unsafe', () => {
       it('throws an error', () => {
         expect(() => {


### PR DESCRIPTION
With the addition of `--banner` option index files may no longer start with '// @create-index'

This new regex looks for '// @create-index' that are either at the beginning of the file (old behavior) or if it is followed by a newline.
Basically it just checks whether it exists in a file or not.

Also added  a test

patch for #20