### PR TITLE
feat: add --resursive and --ignore options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ npm install create-index
 create-index --help
 
 Options:
-  --update, -u  Recursively iterates target directories looking for "index.js"
-                files that start with "// @create-index\n" (create-index index
-                file). Updates found index files. Does not create new index
-                files.                                [boolean] [default: false]
-  --banner      Add a custom banner at the top of the index file        [string]
+  --recursive, -r     Create/update index files recursively. Halts on any unsafe
+                      "index.js" files.               [boolean] [default: false]
+  --ignoreUnsafe, -i  Ignores unsafe "index.js" files instead of halting.
+                                                      [boolean] [default: false]
+  --update, -u        Updates only previously created index files (recursively).
+                                                      [boolean] [default: false]
+  --banner            Add a custom banner at the top of the index file  [string]
 
 Examples:
   create-index ./src ./src/utilities   Creates or updates an existing

--- a/src/bin/create-index.js
+++ b/src/bin/create-index.js
@@ -8,10 +8,26 @@ import {
 const argv = yargs
   .demand(1)
   .options({
+    recursive: {
+      alias: 'r',
+      default: false,
+      description: 'Create/update index files recursively. Halts on any unsafe "index.js" files.',
+      type: 'boolean'
+    }
+  })
+  .options({
+    ignoreUnsafe: {
+      alias: 'i',
+      default: false,
+      description: 'Ignores unsafe "index.js" files instead of halting.',
+      type: 'boolean'
+    }
+  })
+  .options({
     update: {
       alias: 'u',
       default: false,
-      description: 'Recursively iterates target directories looking for "index.js" files that start with "// @create-index\\n" (create-index index file). Updates found index files. Does not create new index files.',
+      description: 'Updates only previously created index files (recursively).',
       type: 'boolean'
     }
   })
@@ -27,5 +43,7 @@ const argv = yargs
 
 writeIndexCli(argv._, {
   banner: argv.banner,
+  ignoreUnsafe: argv.ignoreUnsafe,
+  recursive: argv.recursive,
   updateIndex: argv.update
 });

--- a/src/utilities/findIndexFiles.js
+++ b/src/utilities/findIndexFiles.js
@@ -3,23 +3,18 @@ import _ from 'lodash';
 import glob from 'glob';
 import validateTargetDirectory from './validateTargetDirectory';
 
-export default (directoryPath) => {
-  let targetDirectories;
+export default (directoryPath, options = {}) => {
+  let fileName, targetDirectories;
 
-  targetDirectories = glob.sync(path.join(directoryPath, './**/index.js'));
+  fileName = options.fileName || 'index.js';
+  fileName = './**/' + fileName;
+
+  targetDirectories = glob.sync(path.join(directoryPath, fileName));
 
   targetDirectories = _.filter(targetDirectories, (targetDirectoryPath) => {
-    try {
-      validateTargetDirectory(path.dirname(targetDirectoryPath));
-
-      return true;
-
-      // eslint-disable-next-line no-empty
-    } catch (error) {
-
-    }
-
-    return false;
+    return validateTargetDirectory(path.dirname(targetDirectoryPath), {
+      silent: options.silent
+    });
   });
 
   targetDirectories = _.map(targetDirectories, path.dirname);

--- a/src/utilities/readDirectory.js
+++ b/src/utilities/readDirectory.js
@@ -37,10 +37,12 @@ const removeDuplicates = (files) => {
   });
 };
 
-export default (directoryPath) => {
+export default (directoryPath, options = {}) => {
   let children;
 
-  validateTargetDirectory(directoryPath);
+  if (!validateTargetDirectory(directoryPath, {silent: options.silent})) {
+    return false;
+  }
 
   children = fs.readdirSync(directoryPath);
 

--- a/src/utilities/validateTargetDirectory.js
+++ b/src/utilities/validateTargetDirectory.js
@@ -1,18 +1,26 @@
 import fs from 'fs';
 import path from 'path';
-import _ from 'lodash';
 
-export default (targetDirectory) => {
+export default (targetDirectory, options = {}) => {
+  const silent = options.silent;
   let stats;
 
   try {
     stats = fs.statSync(targetDirectory);
   } catch (error) {
-    throw new Error('Directory "' + targetDirectory + '" does not exist.');
+    if (silent) {
+      return false;
+    } else {
+      throw new Error('Directory "' + targetDirectory + '" does not exist.');
+    }
   }
 
   if (!stats.isDirectory()) {
-    throw new Error('"' + targetDirectory + '" is not a directory.');
+    if (silent) {
+      return false;
+    } else {
+      throw new Error('"' + targetDirectory + '" is not a directory.');
+    }
   }
 
   const indexFilePath = path.resolve(targetDirectory, './index.js');
@@ -25,9 +33,14 @@ export default (targetDirectory) => {
 
   const indexFile = fs.readFileSync(indexFilePath, 'utf8');
 
-  if (!_.startsWith(indexFile, '// @create-index\n')) {
-    throw new Error('"' + indexFilePath + '" unsafe index.');
+  if (!indexFile.match(/(?:^|[\n\r]+)\/\/ @create-index[\n\r]+/)) {
+    if (silent) {
+      return false;
+    } else {
+      throw new Error('"' + indexFilePath + '" unsafe index.');
+    }
   }
 
   return true;
 };
+

--- a/src/utilities/writeIndex.js
+++ b/src/utilities/writeIndex.js
@@ -6,12 +6,11 @@ import validateTargetDirectory from './validateTargetDirectory';
 import readDirectory from './readDirectory';
 import sortByDepth from './sortByDepth';
 
-export default (directoryPaths) => {
-  const sortedDirectoryPaths = sortByDepth(directoryPaths);
-
-  _.forEach(sortedDirectoryPaths, (directoryPath) => {
-    validateTargetDirectory(directoryPath);
-  });
+export default (directoryPaths, options = {}) => {
+  const sortedDirectoryPaths = sortByDepth(directoryPaths)
+    .filter((directoryPath) => {
+      return validateTargetDirectory(directoryPath, {silent: options.ignoreUnsafe});
+    });
 
   _.forEach(sortedDirectoryPaths, (directoryPath) => {
     const siblings = readDirectory(directoryPath);

--- a/test/validateTargetDirectory.js
+++ b/test/validateTargetDirectory.js
@@ -43,5 +43,10 @@ describe('validateTargetDirectory()', () => {
         }).to.throw(Error, '"' + path.resolve(fixturesPath, 'unsafe-index/index.js') + '" unsafe index.');
       });
     });
+    context('unsafe ignored', () => {
+      it('returns false', () => {
+        expect(validateTargetDirectory(path.resolve(fixturesPath, 'unsafe-index'), {silent: true})).to.equal(false);
+      });
+    });
   });
 });


### PR DESCRIPTION
`--resursive`: Create/update index files recursively. Halts on any unsafe "index.js" files.

`--ignore-unsafe`: Ignores unsafe "index.js" files instead of halting.

Fixes #4 #21