### PR TITLE
feat: babylon parser to check default/named exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,6 @@
     "transform-export-extensions",
     "transform-es2015-destructuring",
     "transform-es2015-parameters"
-  ]
+  ],
+  "env": { "development": { "plugins": ["rewire"] } }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   },
   "bin": "./dist/bin/create-index.js",
   "dependencies": {
+    "babylon": "^6.14.1",
+    "babylon-walk": "^1.0.2",
     "chalk": "^1.1.3",
     "glob": "^7.1.1",
     "lodash": "^4.16.6",
@@ -15,6 +17,7 @@
   "description": "Creates ES6 ./index.js file in target directories that imports and exports all sibling files and directories.",
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-plugin-rewire": "^1.0.0",
     "babel-plugin-transform-es2015-destructuring": "^6.18.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-es2015-parameters": "^6.18.0",

--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -14,7 +14,7 @@ const buildExportBlock = (files) => {
   let importBlock;
 
   importBlock = _.map(files, (fileName) => {
-    return 'export ' + safeVariableName(fileName) + ' from \'./' + fileName + '\';';
+    return 'export ' + _.camelCase(safeVariableName(fileName)) + ' from \'./' + fileName + '\';';
   });
 
   importBlock = importBlock.join('\n');

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -4,6 +4,7 @@ export createIndexCode from './createIndexCode.js';
 export findIndexFiles from './findIndexFiles.js';
 export log from './log.js';
 export readDirectory from './readDirectory.js';
+export parseFiles from './parseFiles.js';
 export sortByDepth from './sortByDepth.js';
 export validateTargetDirectory from './validateTargetDirectory.js';
 export writeIndex from './writeIndex.js';

--- a/src/utilities/parseFiles.js
+++ b/src/utilities/parseFiles.js
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+import {parse} from 'babylon';
+import {simple} from 'babylon-walk';
+
+export default (fileNames, directory) => {
+  const cwd = process.cwd();
+
+  return fileNames.map((fileName) => {
+    let absolutePath;
+
+    if (path.isAbsolute(fileName)) {
+      absolutePath = fileName;
+    } else {
+      if (directory) {
+        absolutePath = path.join(directory, fileName);
+      } else {
+        throw new Error('Require base directory for non-absolute fileNames');
+      }
+
+      if (!path.isAbsolute(absolutePath)) {
+        absolutePath = path.join(cwd, absolutePath);
+      }
+    }
+
+    if (fs.statSync(absolutePath).isDirectory()) {
+      absolutePath = path.join(absolutePath, 'index.js');
+    }
+
+    const code = fs.readFileSync(absolutePath, 'utf8');
+
+    const ast = parse(code, {
+      sourceType: 'module'
+    });
+
+    let containsDefaultExport;
+
+    simple(ast, {
+      ExportDefaultDeclaration () {
+        containsDefaultExport = true;
+      }
+    });
+
+    return {
+      containsDefaultExport,
+      fileName
+    };
+  });
+};

--- a/src/utilities/readDirectory.js
+++ b/src/utilities/readDirectory.js
@@ -28,7 +28,7 @@ const hasMultipleExtensions = (fileName) => {
 };
 
 const isSafeName = (fileName) => {
-  return /^[a-z][a-z0-9._]+$/i.test(fileName);
+  return /^[a-z][a-z0-9._-]+$/i.test(fileName);
 };
 
 const removeDuplicates = (files) => {

--- a/src/utilities/writeIndex.js
+++ b/src/utilities/writeIndex.js
@@ -14,7 +14,7 @@ export default (directoryPaths, options = {}) => {
 
   _.forEach(sortedDirectoryPaths, (directoryPath) => {
     const siblings = readDirectory(directoryPath);
-    const indexCode = createIndexCode(siblings);
+    const indexCode = createIndexCode(siblings, {directoryPath});
     const indexFilePath = path.resolve(directoryPath, 'index.js');
 
     fs.writeFileSync(indexFilePath, indexCode);

--- a/src/utilities/writeIndexCli.js
+++ b/src/utilities/writeIndexCli.js
@@ -46,7 +46,8 @@ export default (directoryPaths, options = {}) => {
     const siblings = readDirectory(directoryPath, {silent: options.ignoreUnsafe});
 
     const indexCode = createIndexCode(siblings, {
-      banner: options.banner
+      banner: options.banner,
+      directoryPath
     });
 
     const indexFilePath = path.resolve(directoryPath, 'index.js');

--- a/test/createIndexCode.js
+++ b/test/createIndexCode.js
@@ -7,6 +7,20 @@ import createIndexCode from '../src/utilities/createIndexCode';
 import codeExample from './codeExample';
 
 describe('createIndexCode()', () => {
+  let parseFiles;
+
+  beforeEach(() => {
+    parseFiles = (files) => {
+      return files.map((fileName) => {
+        return {
+          containsDefaultExport: true,
+          fileName
+        };
+      });
+    };
+    createIndexCode.__Rewire__('parseFiles', parseFiles);
+  });
+
   it('describes no children', () => {
     const indexCode = createIndexCode([]);
 

--- a/test/fixtures/write-index/mixed/bar/index.js
+++ b/test/fixtures/write-index/mixed/bar/index.js
@@ -1,1 +1,4 @@
 // @create-index
+
+export const bar1 = () => {};
+export const bar2 = () => {};

--- a/test/fixtures/write-index/mixed/foo.js
+++ b/test/fixtures/write-index/mixed/foo.js
@@ -1,0 +1,2 @@
+export default () => {};
+

--- a/test/fixtures/write-index/mixed/foo/index.js
+++ b/test/fixtures/write-index/mixed/foo/index.js
@@ -1,1 +1,3 @@
 // @create-index
+
+export default () => {};

--- a/test/fixtures/write-index/mixed/index.js
+++ b/test/fixtures/write-index/mixed/index.js
@@ -1,6 +1,6 @@
 // @create-index
 
-import _bar from './bar';
+import * as _bar from './bar';
 export const bar = _bar;
 
 import _foo from './foo.js';

--- a/test/readDirectory.js
+++ b/test/readDirectory.js
@@ -25,7 +25,7 @@ describe('readDirectory()', () => {
     it('gets names of the children directories', () => {
       const names = readDirectory(path.resolve(fixturesPath, 'children-directories-unsafe-name'));
 
-      expect(names).to.deep.equal(['present']);
+      expect(names).to.deep.equal(['bar-bar', 'foo-foo', 'present']);
     });
   });
   context('target directory contains ./index.js', () => {

--- a/test/writeIndex.js
+++ b/test/writeIndex.js
@@ -24,12 +24,13 @@ describe('writeIndex()', () => {
 
     writeIndex([path.resolve(fixturesPath, 'mixed')]);
 
+    console.log({indexFilePath});
     const indexCode = fs.readFileSync(indexFilePath, 'utf8');
 
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-import _bar from './bar';
+import * as _bar from './bar';
 export const bar = _bar;
 
 import _foo from './foo.js';


### PR DESCRIPTION
Uses Babylon parser to parse the file to check if it contains a default export.

If a file now contains a default export, the behaviour will be the same as before.

But if the file doesn't contain any default exports, assuming it has only named exports, it uses `* as` when creating its index.


Eg. Default export: (same as before)
```js
// foo.js

export default () => {}
```
will create ine the index:
```
import _foo from './foo'
export const foo = _foo
export {
  foo
}
```


Eg. Named exports:
```js
// foo.js

export const foo1 = () => {}
export const foo2 = () => {}
```
will create ine the index:
```
import * as _foo from './foo'
export const foo = _foo
export {
  foo
}
```

Builds on #18, addresses #11