### PR TITLE
Support for proper export syntax

### DIFF
--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -14,7 +14,7 @@ const buildExportBlock = (files) => {
   let importBlock;
 
   importBlock = _.map(files, (fileName) => {
-    return 'export ' + safeVariableName(fileName) + ' from \'./' + fileName + '\';';
+    return 'export { default as ' + safeVariableName(fileName) + ' } from \'./' + fileName + '\';';
   });
 
   importBlock = importBlock.join('\n');

--- a/test/createIndexCode.js
+++ b/test/createIndexCode.js
@@ -20,7 +20,7 @@ describe('createIndexCode()', () => {
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export foo from './foo';
+export { default as foo } from './foo';
         `));
   });
   it('describes multiple children', () => {
@@ -29,8 +29,8 @@ export foo from './foo';
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export bar from './bar';
-export foo from './foo';
+export { default as bar } from './bar';
+export { default as foo } from './foo';
         `));
   });
   context('file with extension', () => {
@@ -40,7 +40,7 @@ export foo from './foo';
       expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export foo from './foo.js';
+export { default as foo } from './foo.js';
             `));
     });
   });
@@ -51,8 +51,8 @@ export foo from './foo.js';
       expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export bar from './bar';
-export foo from './foo';
+export { default as bar } from './bar';
+export { default as foo } from './foo';
             `));
     });
   });

--- a/test/fixtures/write-index/mixed/index.js
+++ b/test/fixtures/write-index/mixed/index.js
@@ -1,5 +1,5 @@
 // @create-index
 
-export bar from './bar';
-export foo from './foo.js';
+export { default as bar } from './bar';
+export { default as foo } from './foo.js';
 

--- a/test/writeIndex.js
+++ b/test/writeIndex.js
@@ -29,8 +29,8 @@ describe('writeIndex()', () => {
     expect(indexCode).to.equal(codeExample(`
 // @create-index
 
-export bar from './bar';
-export foo from './foo.js';
+export { default as bar } from './bar';
+export { default as foo } from './foo.js';
         `));
   });
 });


### PR DESCRIPTION
As seen in #30, it is possible to export default in a way that don't require any plugin or non standard ES2015 features.