### PR TITLE
using writeIndex programatically was not respecting passed options configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/utilities/writeIndex.js
+++ b/src/utilities/writeIndex.js
@@ -17,7 +17,7 @@ export default (directoryPaths, options = {}) => {
     const config = readIndexConfig(directoryPath);
     const optionsWithConfig = Object.assign({}, options, {config});
     const siblings = readDirectory(directoryPath, optionsWithConfig);
-    const indexCode = createIndexCode(siblings, {config});
+    const indexCode = createIndexCode(siblings, optionsWithConfig);
     const indexFilePath = path.resolve(directoryPath, 'index.js');
 
     fs.writeFileSync(indexFilePath, indexCode);


### PR DESCRIPTION
Fixes #39 

.gitattributes file also added to allow for Windows development 