### PR TITLE
(Feature) Add custom template function

### DIFF
--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import exportNamedIndex from './exportNamedIndex';
 
 const safeVariableName = (fileName) => {
   const indexOfDot = fileName.indexOf('.');
@@ -10,11 +11,11 @@ const safeVariableName = (fileName) => {
   }
 };
 
-const buildExportBlock = (files) => {
+const buildExportBlock = (files, templateFunction) => {
   let importBlock;
 
   importBlock = _.map(files, (fileName) => {
-    return 'export { default as ' + safeVariableName(fileName) + ' } from \'./' + fileName + '\';';
+    return templateFunction(safeVariableName(fileName), fileName);
   });
 
   importBlock = importBlock.join('\n');
@@ -22,7 +23,7 @@ const buildExportBlock = (files) => {
   return importBlock;
 };
 
-export default (filePaths, options = {}) => {
+export default (filePaths, options = {}, templateFunction = exportNamedIndex) => {
   let code;
   let configCode;
 
@@ -48,7 +49,7 @@ export default (filePaths, options = {}) => {
   if (filePaths.length) {
     const sortedFilePaths = filePaths.sort();
 
-    code += buildExportBlock(sortedFilePaths) + '\n\n';
+    code += buildExportBlock(sortedFilePaths, templateFunction) + '\n\n';
   }
 
   return code;

--- a/src/utilities/exportNamedIndex.js
+++ b/src/utilities/exportNamedIndex.js
@@ -1,0 +1,3 @@
+export default (variableName, fileName) => {
+  return 'export { default as ' + variableName + ' } from \'./' + fileName + '\';';
+};

--- a/src/utilities/writeIndex.js
+++ b/src/utilities/writeIndex.js
@@ -6,8 +6,9 @@ import validateTargetDirectory from './validateTargetDirectory';
 import readDirectory from './readDirectory';
 import readIndexConfig from './readIndexConfig';
 import sortByDepth from './sortByDepth';
+import exportNamedIndex from './exportNamedIndex';
 
-export default (directoryPaths, options = {}) => {
+export default (directoryPaths, options = {}, templateFunction = exportNamedIndex) => {
   const sortedDirectoryPaths = sortByDepth(directoryPaths)
     .filter((directoryPath) => {
       return validateTargetDirectory(directoryPath, {silent: options.ignoreUnsafe});
@@ -17,7 +18,7 @@ export default (directoryPaths, options = {}) => {
     const config = readIndexConfig(directoryPath);
     const optionsWithConfig = Object.assign({}, options, {config});
     const siblings = readDirectory(directoryPath, optionsWithConfig);
-    const indexCode = createIndexCode(siblings, optionsWithConfig);
+    const indexCode = createIndexCode(siblings, optionsWithConfig, templateFunction);
     const indexFilePath = path.resolve(directoryPath, 'index.js');
 
     fs.writeFileSync(indexFilePath, indexCode);

--- a/test/createIndexCode.js
+++ b/test/createIndexCode.js
@@ -72,4 +72,20 @@ export { default as foo } from './foo';
       `));
     });
   });
+
+  context('with custom template function', () => {
+    it('should use template function', () => {
+      const config = {
+        ignore: ['/^zoo/']
+      };
+      const indexCode = createIndexCode(['foo', 'bar'], {config}, (varName, fileName) => `export * as ${varName} from './${fileName}';`);
+
+      expect(indexCode).to.equal(codeExample(`
+// @create-index {"ignore":["/^zoo/"]}
+
+export * as bar from './bar';
+export * as foo from './foo';
+      `));
+    });
+  });
 });


### PR DESCRIPTION
- [x] Tests and lint pass
- [x] Added new test

This pull request adds the ability to customize the output of create-index, to create different kinds of exports:

```js
writeIndex(['./target_directory'], {}, (varName, fileName) => `export * as ${varName} from './${fileName}`);

// export * as Example from './Example';
```

Doing so allows the customization for a couple uses cases I've experienced personally and have seen in the issues here. 

This change only affects the API. I was not sure what to do for the client, I would suppose a good way to add support would to add a `--template file/path.js` flag where the JS file must export a function. @gajus please let me know if you have any thoughts on that matter.

Cheers!