### PR TITLE
Add option to exclude directories from index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,34 @@ npm install create-index
 create-index --help
 
 Options:
-  --recursive, -r     Create/update index files recursively. Halts on any unsafe
-                      "index.js" files.               [boolean] [default: false]
-  --ignoreUnsafe, -i  Ignores unsafe "index.js" files instead of halting.
+  --recursive, -r          Create/update index files recursively. Halts on any
+                           unsafe "index.js" files.   [boolean] [default: false]
+  --ignoreUnsafe, -i       Ignores unsafe "index.js" files instead of halting.
                                                       [boolean] [default: false]
-  --update, -u        Updates only previously created index files (recursively).
+  --ignoreDirectories, -d  Ignores importing directories into the index file,
+                           even if they have a safe "index.js".
                                                       [boolean] [default: false]
-  --banner            Add a custom banner at the top of the index file  [string]
+  --update, -u             Updates only previously created index files
+                           (recursively).             [boolean] [default: false]
+  --banner                 Add a custom banner at the top of the index file
+                                                                        [string]
+  --extensions, -x         Allows some extensions to be parsed as valid source.
+                           First extension will always be preferred to homonyms
+                           with another allowed extension.
+                                                       [array] [default: ["js"]]
 
 Examples:
-  create-index ./src ./src/utilities   Creates or updates an existing
-                                       create-index index file in the target
-                                       (./src, ./src/utilities) directories.
-  create-index --update ./src ./tests  Finds all create-index index files in the
-                                       target directories and descending
-                                       directories. Updates found index files.
+  create-index ./src ./src/utilities      Creates or updates an existing
+                                          create-index index file in the target
+                                          (./src, ./src/utilities) directories.
+  create-index --update ./src ./tests     Finds all create-index index files in
+                                          the target directories and descending
+                                          directories. Updates found index
+                                          files.
+  create-index ./src --extensions js jsx  Creates or updates an existing
+                                          create-index index file in the target
+                                          (./src) directory for both .js and
+                                          .jsx extensions.
 ```
 
 ### Using `create-index` Programmatically

--- a/src/bin/create-index.js
+++ b/src/bin/create-index.js
@@ -24,6 +24,14 @@ const argv = yargs
     }
   })
   .options({
+    ignoreDirectories: {
+      alias: 'd',
+      default: false,
+      description: 'Ignores importing directories into the index file, even if they have a safe "index.js".',
+      type: 'boolean'
+    }
+  })
+  .options({
     update: {
       alias: 'u',
       default: false,
@@ -45,14 +53,24 @@ const argv = yargs
       type: 'array'
     }
   })
-  .example('create-index ./src ./src/utilities', 'Creates or updates an existing create-index index file in the target (./src, ./src/utilities) directories.')
-  .example('create-index --update ./src ./tests', 'Finds all create-index index files in the target directories and descending directories. Updates found index files.')
-  .example('create-index ./src --extensions js jsx', 'Creates or updates an existing create-index index file in the target (./src) directory for both .js and .jsx extensions.')
+  .example(
+    'create-index ./src ./src/utilities',
+    'Creates or updates an existing create-index index file in the target (./src, ./src/utilities) directories.'
+  )
+  .example(
+    'create-index --update ./src ./tests',
+    'Finds all create-index index files in the target directories and descending directories. Updates found index files.'
+  )
+  .example(
+    'create-index ./src --extensions js jsx',
+    'Creates or updates an existing create-index index file in the target (./src) directory for both .js and .jsx extensions.'
+  )
   .argv;
 
 writeIndexCli(argv._, {
   banner: argv.banner,
   extensions: argv.extensions,
+  ignoreDirectories: argv.ignoreDirectories,
   ignoreUnsafe: argv.ignoreUnsafe,
   recursive: argv.recursive,
   updateIndex: argv.update

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,10 +1,10 @@
 // @create-index
 
-export createIndexCode from './createIndexCode.js';
-export findIndexFiles from './findIndexFiles.js';
-export log from './log.js';
-export readDirectory from './readDirectory.js';
-export sortByDepth from './sortByDepth.js';
-export validateTargetDirectory from './validateTargetDirectory.js';
-export writeIndex from './writeIndex.js';
-export writeIndexCli from './writeIndexCli.js';
+export createIndexCode from './createIndexCode';
+export findIndexFiles from './findIndexFiles';
+export log from './log';
+export readDirectory from './readDirectory';
+export sortByDepth from './sortByDepth';
+export validateTargetDirectory from './validateTargetDirectory';
+export writeIndex from './writeIndex';
+export writeIndexCli from './writeIndexCli';

--- a/src/utilities/readDirectory.js
+++ b/src/utilities/readDirectory.js
@@ -79,7 +79,7 @@ export default (directoryPath, options = {}) => {
   const {
     extensions = ['js'],
     config = {},
-    ignoreDirs = false
+    ignoreDirectories = false
   } = options;
 
   let children;
@@ -112,7 +112,7 @@ export default (directoryPath, options = {}) => {
       return false;
     }
 
-    if (isDirectory && (!hasIndex(absolutePath) || ignoreDirs)) {
+    if (isDirectory && (!hasIndex(absolutePath) || ignoreDirectories)) {
       return false;
     }
 

--- a/src/utilities/readDirectory.js
+++ b/src/utilities/readDirectory.js
@@ -78,7 +78,8 @@ export default (directoryPath, options = {}) => {
 
   const {
     extensions = ['js'],
-    config = {}
+    config = {},
+    ignoreDirs = false
   } = options;
 
   let children;
@@ -111,7 +112,7 @@ export default (directoryPath, options = {}) => {
       return false;
     }
 
-    if (isDirectory && !hasIndex(absolutePath)) {
+    if (isDirectory && (!hasIndex(absolutePath) || ignoreDirs)) {
       return false;
     }
 

--- a/src/utilities/writeIndexCli.js
+++ b/src/utilities/writeIndexCli.js
@@ -50,6 +50,7 @@ export default (directoryPaths, options = {}) => {
     const siblings = readDirectory(directoryPath, {
       config,
       extensions: options.extensions,
+      ignoreDirs: options.ignoreDirectories,
       silent: options.ignoreUnsafe
     });
 

--- a/src/utilities/writeIndexCli.js
+++ b/src/utilities/writeIndexCli.js
@@ -50,7 +50,7 @@ export default (directoryPaths, options = {}) => {
     const siblings = readDirectory(directoryPath, {
       config,
       extensions: options.extensions,
-      ignoreDirs: options.ignoreDirectories,
+      ignoreDirectories: options.ignoreDirectories,
       silent: options.ignoreUnsafe
     });
 

--- a/test/readDirectory.js
+++ b/test/readDirectory.js
@@ -35,8 +35,8 @@ describe('readDirectory()', () => {
       expect(names).to.deep.equal(['bar', 'foo']);
     });
 
-    it('excludes directories if ignoreDirs = true', () => {
-      const names = readDirectory(path.resolve(fixturesPath, 'children-index'), {ignoreDirs: true});
+    it('excludes directories if ignoreDirectories = true', () => {
+      const names = readDirectory(path.resolve(fixturesPath, 'children-index'), {ignoreDirectories: true});
 
       expect(names).to.deep.equal([]);
     });

--- a/test/readDirectory.js
+++ b/test/readDirectory.js
@@ -34,6 +34,12 @@ describe('readDirectory()', () => {
 
       expect(names).to.deep.equal(['bar', 'foo']);
     });
+
+    it('excludes directories if ignoreDirs = true', () => {
+      const names = readDirectory(path.resolve(fixturesPath, 'children-index'), {ignoreDirs: true});
+
+      expect(names).to.deep.equal([]);
+    });
   });
   context('target directory contains files', () => {
     it('refers to the files (with extension)', () => {


### PR DESCRIPTION
Newer versions of `react-scripts` no longer seem to play friendly with `create-index`, specifically because of the rules around whether directories get imported, I've added an option to blanket ignore including all directories to an index, which works a treat for my work apps. Let me know if it's something you'd like merged and I'll update the README.md as well.