### PR TITLE
[nanoutils] cannot use create-index for short folders

### DIFF
--- a/src/utilities/readDirectory.js
+++ b/src/utilities/readDirectory.js
@@ -17,7 +17,7 @@ const hasMultipleExtensions = (fileName) => {
 };
 
 const isSafeName = (fileName) => {
-  return /^[a-z][a-z0-9._]+$/i.test(fileName);
+  return /^[a-z_][a-z0-9._]*$/i.test(fileName);
 };
 
 const stripExtension = (fileName) => {

--- a/test/fixtures/read-directory/children-directories-short-name/F/index.js
+++ b/test/fixtures/read-directory/children-directories-short-name/F/index.js
@@ -1,0 +1,1 @@
+// @create-index

--- a/test/fixtures/read-directory/children-directories-short-name/T/index.js
+++ b/test/fixtures/read-directory/children-directories-short-name/T/index.js
@@ -1,0 +1,1 @@
+// @create-index

--- a/test/fixtures/read-directory/children-directories-short-name/__/index.js
+++ b/test/fixtures/read-directory/children-directories-short-name/__/index.js
@@ -1,0 +1,1 @@
+// @create-index

--- a/test/fixtures/read-directory/children-directories-short-name/o/index.js
+++ b/test/fixtures/read-directory/children-directories-short-name/o/index.js
@@ -1,0 +1,1 @@
+// @create-index

--- a/test/readDirectory.js
+++ b/test/readDirectory.js
@@ -21,6 +21,13 @@ describe('readDirectory()', () => {
       expect(names).to.deep.equal(['present.js']);
     });
   });
+  context('target directory contains child directories (short safe name)', () => {
+    it('gets names of the children directories', () => {
+      const names = readDirectory(path.resolve(fixturesPath, 'children-directories-short-name'));
+
+      expect(names).to.deep.equal(['F', 'T', '__', 'o']);
+    });
+  });
   context('target directory contains child directories (unsafe name)', () => {
     it('gets names of the children directories', () => {
       const names = readDirectory(path.resolve(fixturesPath, 'children-directories-unsafe-name'));


### PR DESCRIPTION
**Real examples**:
* __
* F
* o
* T

These methods haven't been included before, you can check it for https://www.npmjs.com/package/nanoutils/v/0.1.1 and previous versions (_unfortunately_ 😢)

**Solution**: you can start file from `_` and one symbol is required to make folders and files safe (not 2 as before)