### PR TITLE
Support module type=CJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - node
-  - 7
-  - 6
-  - 5
+  - 14
+  - 12
+  - 10
 script:
   - npm run lint
   - npm run test

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Options:
                            with another allowed extension.
                                                        [array] [default: ["js"]]
   --outputFile, -o         Output file            [string] [default: "index.js"]                                                      [array] [default: ["js"]]
+  --moduleType, -o         Module type, "ES6" or "CJS"      [string] [default: "ES6"]
 
 Examples:
   create-index ./src ./src/utilities      Creates or updates an existing

--- a/src/bin/create-index.js
+++ b/src/bin/create-index.js
@@ -63,6 +63,13 @@ const argv = yargs
       type: 'string',
     },
   })
+  .options({
+    moduleType: {
+      default: 'ES6',
+      description: 'Module Type ["ES6", "CJS"]',
+      type: 'string',
+    },
+  })
   .example(
     'create-index ./src ./src/utilities',
     'Creates or updates an existing create-index index file in the target (./src, ./src/utilities) directories.',
@@ -83,6 +90,7 @@ writeIndexCli(argv._, {
   ignoreDirectories: argv.ignoreDirectories,
   ignoreUnsafe: argv.ignoreUnsafe,
   outputFile: argv.outputFile,
+  moduleType: argv.moduleType,
   recursive: argv.recursive,
   updateIndex: argv.update,
 });

--- a/src/bin/create-index.js
+++ b/src/bin/create-index.js
@@ -89,8 +89,8 @@ writeIndexCli(argv._, {
   extensions: argv.extensions,
   ignoreDirectories: argv.ignoreDirectories,
   ignoreUnsafe: argv.ignoreUnsafe,
-  outputFile: argv.outputFile,
   moduleType: argv.moduleType,
+  outputFile: argv.outputFile,
   recursive: argv.recursive,
   updateIndex: argv.update,
 });

--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -10,12 +10,25 @@ const safeVariableName = (fileName) => {
   }
 };
 
-const buildExportBlock = (files) => {
+const buildExportBlock = (files, moduleType) => {
   let importBlock;
+  
+  if(moduleType === 'CJS'){
+    importBlock = _.map(files, (fileName) => {
+      return 'const ' + safeVariableName(fileName) + ' = require(\'./' + fileName + '\');';
+    });
 
-  importBlock = _.map(files, (fileName) => {
-    return 'export { default as ' + safeVariableName(fileName) + ' } from \'./' + fileName + '\';';
-  });
+    importBlock.push('');
+    importBlock.push('module.exports = {');
+    importBlock.push(..._.map(files, (fileName) => {
+      return '  ' + safeVariableName(fileName) + ',';
+    }));
+    importBlock.push('}');
+  }else{
+    importBlock = _.map(files, (fileName) => {
+      return 'export { default as ' + safeVariableName(fileName) + ' } from \'./' + fileName + '\';';
+    });
+  }
 
   importBlock = importBlock.join('\n');
 
@@ -25,9 +38,11 @@ const buildExportBlock = (files) => {
 export default (filePaths, options = {}) => {
   let code;
   let configCode;
+  let moduleType;
 
   code = '';
   configCode = '';
+  moduleType = options.moduleType;
 
   if (options.banner) {
     const banners = _.isArray(options.banner) ? options.banner : [options.banner];
@@ -45,10 +60,11 @@ export default (filePaths, options = {}) => {
 
   code += '// @create-index' + configCode + '\n\n';
 
+
   if (filePaths.length) {
     const sortedFilePaths = filePaths.sort();
 
-    code += buildExportBlock(sortedFilePaths) + '\n\n';
+    code += buildExportBlock(sortedFilePaths, moduleType) + '\n\n';
   }
 
   return code;

--- a/src/utilities/createIndexCode.js
+++ b/src/utilities/createIndexCode.js
@@ -12,8 +12,8 @@ const safeVariableName = (fileName) => {
 
 const buildExportBlock = (files, moduleType) => {
   let importBlock;
-  
-  if(moduleType === 'CJS'){
+
+  if (moduleType === 'CJS') {
     importBlock = _.map(files, (fileName) => {
       return 'const ' + safeVariableName(fileName) + ' = require(\'./' + fileName + '\');';
     });
@@ -24,7 +24,7 @@ const buildExportBlock = (files, moduleType) => {
       return '  ' + safeVariableName(fileName) + ',';
     }));
     importBlock.push('}');
-  }else{
+  } else {
     importBlock = _.map(files, (fileName) => {
       return 'export { default as ' + safeVariableName(fileName) + ' } from \'./' + fileName + '\';';
     });
@@ -38,11 +38,10 @@ const buildExportBlock = (files, moduleType) => {
 export default (filePaths, options = {}) => {
   let code;
   let configCode;
-  let moduleType;
+  const moduleType = options.moduleType;
 
   code = '';
   configCode = '';
-  moduleType = options.moduleType;
 
   if (options.banner) {
     const banners = _.isArray(options.banner) ? options.banner : [options.banner];
@@ -59,7 +58,6 @@ export default (filePaths, options = {}) => {
   }
 
   code += '// @create-index' + configCode + '\n\n';
-
 
   if (filePaths.length) {
     const sortedFilePaths = filePaths.sort();

--- a/src/utilities/writeIndexCli.js
+++ b/src/utilities/writeIndexCli.js
@@ -59,8 +59,8 @@ export default (directoryPaths, options = {}) => {
 
     const indexCode = createIndexCode(siblings, {
       banner: options.banner,
-      moduleType: options.moduleType,
       config,
+      moduleType: options.moduleType,
     });
 
     const indexFilePath = path.resolve(directoryPath, options.outputFile || 'index.js');

--- a/src/utilities/writeIndexCli.js
+++ b/src/utilities/writeIndexCli.js
@@ -17,6 +17,7 @@ export default (directoryPaths, options = {}) => {
 
   log('Target directories', sortedDirectoryPaths);
   log('Output file', options.outputFile);
+  log('Module type', options.moduleType);
   if (options.updateIndex) {
     log('Update index:', options.updateIndex ? chalk.green('true') : chalk.red('false'));
   } else {
@@ -58,6 +59,7 @@ export default (directoryPaths, options = {}) => {
 
     const indexCode = createIndexCode(siblings, {
       banner: options.banner,
+      moduleType: options.moduleType,
       config,
     });
 

--- a/test/createIndexCode.js
+++ b/test/createIndexCode.js
@@ -72,4 +72,22 @@ export { default as foo } from './foo';
       `));
     });
   });
+
+  context('with config (moduleType=CJS)', () => {
+    it('handle moduleType=CJS', () => {
+      const indexCode = createIndexCode(['foo', 'bar'], {moduleType: 'CJS'});
+
+      expect(indexCode).to.equal(codeExample(`
+// @create-index
+
+const bar = require('./bar');
+const foo = require('./foo');
+
+module.exports = {
+  bar,
+  foo,
+}
+      `));
+    });
+  });
 });


### PR DESCRIPTION
Example output of index.js for CJS
// @create-index

const bar = require('./bar.js');
const foo = require('./foo.js');

module.exports = {
  bar,
  foo,
}