### PR TITLE
Update findIndexFiles.js

### DIFF
--- a/src/utilities/findIndexFiles.js
+++ b/src/utilities/findIndexFiles.js
@@ -7,7 +7,7 @@ export default (directoryPath, options = {}) => {
   let fileName;
   let targetDirectories;
 
-  fileName = options.fileName || 'index.js';
+  fileName = options.outputFile || 'index.js';
   fileName = './**/' + fileName;
 
   targetDirectories = glob.sync(path.join(directoryPath, fileName));


### PR DESCRIPTION
I believe this will fix the issue when working on the typescript project and the folder is not exported if it contains index.ts file only and not index.js